### PR TITLE
Dynamic IP handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+DISCLAIMER: First github adventure... NFI how to properly attribute this!
+
 Introduction
 ============
 
@@ -6,7 +8,7 @@ Purpose
 
 This project / repository contains a Python script and description on how to make the [UniFi Security Gateway](https://www.ui.com/unifi-routing/usg/) DNS service automatically resolve aliases (and only aliases) specified in the UniFi controller.
 
-**This means you only have to define a client alias & a fixed IP address in the UniFi UI and the DNS server is automatically updated with that entry!**
+**This means you only have to define a client alias and/or a fixed IP address in the UniFi UI and the DNS server is automatically updated with that entry!**
 
 Rationale
 ---------
@@ -91,8 +93,8 @@ DNS Configuration
 Of course the DNS server needs to be informed about this new file as well. Here's an example for that configuration:
 
 ```
-# Don't use the default /etc/hosts file.
-set service dns forwarding options no-hosts
+# Don't use the default /etc/hosts file.  I did not use this.
+#set service dns forwarding options no-hosts
 
 # Use the generated /config/user-data/hosts instead.
 set service dns forwarding options addn-hosts=/config/user-data/hosts 

--- a/usg-easy-dns.py
+++ b/usg-easy-dns.py
@@ -112,7 +112,7 @@ class UniFiController:
         clients = []
 
         for client in self.get_clients():
-            if 'fixed_ip' not in client:
+            if 'use_fixedip' not in client:
                 continue
                 
             name = client['name'] if 'name' in client else client['hostname']
@@ -128,7 +128,10 @@ class UniFiController:
                         if client['mac'] in line:
                             ip = line.split(" ")[2]
                             LOGGER.debug("Got DHCP IP for %s", name)
-                            break 
+                            break
+                    else:
+                        LOGGER.debug("No IP found for %s, skipping", name)
+                        continue
             
             LOGGER.debug('Adding host %s with IP address %s', name, ip)
             clients.append((ip, name))

--- a/usg-easy-dns.py
+++ b/usg-easy-dns.py
@@ -114,12 +114,22 @@ class UniFiController:
         for client in self.get_clients():
             if 'fixed_ip' not in client:
                 continue
-
-            ip   = client['fixed_ip']
+                
             name = client['name'] if 'name' in client else client['hostname']
             name = re.sub(pattern=r'[\s_-]+', repl='-', string=name, flags=re.IGNORECASE)
             name = re.sub(pattern='[^0-9a-z-]', repl='', string=name, flags=re.IGNORECASE)
 
+            if client['use_fixedip']:
+                ip = client['fixed_ip']    
+                LOGGER.debug("Got Fixed IP for %s", name)                          
+            else:
+                with open("/config/dnsmasq-dhcp.leases","r") as dhcpfile:
+                    for line in dhcpfile:
+                        if client['mac'] in line:
+                            ip = line.split(" ")[2]
+                            LOGGER.debug("Got DHCP IP for %s", name)
+                            break 
+            
             LOGGER.debug('Adding host %s with IP address %s', name, ip)
             clients.append((ip, name))
 


### PR DESCRIPTION
Hi There,
I knew I should have figured out how to make a PR sooner :)
I made some changes to the script to handle devices that have been given an Alias, but not a fixed IP, ie they are on DHCP.  A few devices do not register nice hostnames with DHCP, this allows those names to be overridden with an alias.
* The `use_fixedip` field appears to always be present for a 'configured' client, the `fixed_ip` field is not always present.
* If the configured client has a fixed IP that will be used, otherwise the IP will be retrieved from the DHCP leases file.
There is probably better ways to query the DHCP leases, but this seems to work fine on my small network.
Disclaimer:  The sum total of my Python experience is as long as it took to figure out how to make these changes :)
Cheers.
